### PR TITLE
Correctly filter messages coming from Hubot itself

### DIFF
--- a/src/0_3.coffee
+++ b/src/0_3.coffee
@@ -34,7 +34,7 @@ class LCB extends Adapter
     for str in strings
       @socket.emit 'messages:create',
         'room': user.room,
-        'text': "@#{user.name}: #{str}"
+        'text': "@#{user.user.name} #{str}"
 
   run: ->
     @socket = io.connect chatURL

--- a/src/0_3.coffee
+++ b/src/0_3.coffee
@@ -57,7 +57,9 @@ class LCB extends Adapter
         user = @robot.brain.userForId message.owner.id,
           room: message.room.id,
           name: message.owner.username
-        @receive new TextMessage user, message.text
+        # Messages coming from Hubot itself must be filtered by the adapter
+        unless message.owner.username is @robot.name
+            @receive new TextMessage user, message.text
 
     @socket.on 'error', (err) =>
       console.log err

--- a/src/0_3.coffee
+++ b/src/0_3.coffee
@@ -59,7 +59,7 @@ class LCB extends Adapter
           name: message.owner.username
         # Messages coming from Hubot itself must be filtered by the adapter
         unless message.owner.username is @robot.name
-            @receive new TextMessage user, message.text
+          @receive new TextMessage user, message.text
 
     @socket.on 'error', (err) =>
       console.log err


### PR DESCRIPTION
Hubot assumes the adapter will not transmit "echo" messages coming from Hubot itself. This can be seen here: https://github.com/github/hubot/blob/aff09bf250b281b0c4b878aae1d03e85cfe8717c/src/adapters/campfire.coffee#L71-L74

I assume this bug did not show up earlier because it has two conditions:
1. The bot must use `hear` commands, `respond` commands won't trigger it.
2. The bot writes a string that will trigger its own `hear` command, also unlikely.

I also fixed the string interpolation for `reply`, which was showing as `@undefined`.