### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ hubot --create myhubot
 
 You might also like to use the [yeoman hubot installer](https://github.com/github/generator-hubot). Check out the [hubot docs](https://hubot.github.com/docs/) for help getting a hubot running.
 
- ### 2. Install the Adapter
+### 2. Install the Adapter
 
 Once your hubot is working, go into your new bot's directory to perform acts of `npm`. 
 
@@ -31,7 +31,6 @@ Install the adapter:
 ### 3. Optional environment variables
 
 Set the following environment variables:
-
 
 - `HUBOT_LCB_ROOMS` You can see these IDs in the URL for the room. NOTE: this is a _comma-separated list_. 
 - `HUBOT_LCB_TOKEN` can be found in the Let's Chat interface. Click on your username and look under "Auth Tokens."

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is a WIP and will probably be unreliable for a while, so use at your own ri
 
 ## Overview
 
-You already have a Let's Chat (LC) server running, now you want to add hubot.
+You already have a Let's Chat server running, now you want to add hubot.
 
-We're going to install a new stock hubot, and install this hubot "adapter" so it can talk to LC.
+We're going to install a new stock hubot, and install this hubot "adapter" so it can talk to Let's Chat.
 
 ## 1. Install a hubot
 
@@ -20,11 +20,11 @@ You might also like to use the [yeoman hubot installer](https://github.com/githu
 
 ### 2. Install the Adapter
 
-Once your hubot is working, go into your new bot's directory to perform acts of `npm`. 
+Once your hubot is working, change directory into your new bot code:
 
 `cd myhubot`
 
-Install the adapter:
+Then install the adapter with npm:
 
 `npm install hubot-lets-chat --save`
 
@@ -50,15 +50,15 @@ export HUBOT_LCB_HOSTNAME=localhost
 export HUBOT_LCB_PORT=5000
 ```
 
-## 4. Create a bot user in Let's Chat
+## 4. Create a new user in Let's Chat
 
 In the Let's Chat web interface, create a user with the same @name as your bot, like `@myhubot`.
 
-Tip: Let's Chat uses [gravatar](http://gravatar.com for avatars. So if you want to customize the bot avatar, you could use a gmail alias like myemail+hubot@gmail.com, then customize that avatar in Gravatar.
+You can customize it when you boot the hutbot, like `./bin/hubot --adapter lets-chat --name myfancyname`.
+
+Tip for Gmail users: Let's Chat 0.3 uses [gravatar]("http://gravatar.com") for avatars. So if you want to customize the bot avatar, you could use a Gmail alias like myemail+hubot@gmail.com, then customize that avatar in Gravatar.
 
 ### 5. Let's go! Start the server.
-
-Enjoy skynet, I hope you're happy with yourself.
 
 To get the hubot running, start the server with the `lets-chat` adapter. 
 
@@ -67,3 +67,5 @@ bin/hubot -a lets-chat
 ```
 
 If everything goes well, your bot will join you in your Let's Chat instance.
+
+Enjoy skynet, I hope you're happy with yourself.

--- a/README.md
+++ b/README.md
@@ -2,57 +2,69 @@
 
 This is a WIP and will probably be unreliable for a while, so use at your own risk!
 
-## Setup
+## Overview
 
-Create a new brobot
+You already have a Let's Chat (LC) server running, now you want to add hubot.
+
+We're going to install a new stock hubot, and install this hubot "adapter" so it can talk to LC.
+
+## 1. Install a hubot
+
+Create a new hubot. There are several ways to do this but the simplest might be using this `hubot` command:
+
 ```
 hubot --create myhubot
 ```
 
-Go into your new bot's directory
-```
-cd myhubot
-```
+You might also like to use the [yeoman hubot installer](https://github.com/github/generator-hubot). Check out the [hubot docs](https://hubot.github.com/docs/) for help getting a hubot running.
 
-### Let's Chat 0.3+
+ ### 2. Install the Adapter
 
-Install this adapter via npm
-```
-npm install hubot-lets-chat --save
-```
+Once your hubot is working, go into your new bot's directory to perform acts of `npm`. 
 
-Set the following environment variables for Let's Chat 0.3
+`cd myhubot`
+
+Install the adapter:
+
+`npm install hubot-lets-chat --save`
+
+### 3. Optional environment variables
+
+Set the following environment variables:
+
+
+- `HUBOT_LCB_ROOMS` You can see these IDs in the URL for the room. NOTE: this is a _comma-separated list_. 
+- `HUBOT_LCB_TOKEN` can be found in the Let's Chat interface. Click on your username and look under "Auth Tokens."
+
+Set these two environment variables with `export`:
+
 ```
 export HUBOT_LCB_TOKEN=NTRiNjg5NmYyMDZiMzEwMDAwYTAxNmZiOjE0ZTg2ODMwYz...
 export HUBOT_LCB_ROOMS=5279facb1015642226000011,5394ffbabdea44e815000003
 ```
 
-### Let's Chat 0.2
+Additionally, three more environment variables are *optional* and have default values:
 
-Install this adapter via npm
-```
-npm install hubot-lets-chat@0.0.4 --save
-```
-
-Set the following environment variables for Let's Chat 0.2
-```
-export HUBOT_LCB_USER=user@example.com
-export HUBOT_LCB_PASSWORD=ohmygodthisisbadpractice
-export HUBOT_LCB_ROOMS=5279facb1015642226000011,5394ffbabdea44e815000003
-```
-
-### Optional environment variables
-
-These environment variables are *optional* and have default values
 ```
 export HUBOT_LCB_PROTOCOL=http
 export HUBOT_LCB_HOSTNAME=localhost
 export HUBOT_LCB_PORT=5000
 ```
 
-### Let's go!
+## 4. Create a bot user in Let's Chat
 
-Enjoy skynet, I hope you're happy with yourself
+In the Let's Chat web interface, create a user with the same @name as your bot, like `@myhubot`.
+
+Tip: Let's Chat uses [gravatar](http://gravatar.com for avatars. So if you want to customize the bot avatar, you could use a gmail alias like myemail+hubot@gmail.com, then customize that avatar in Gravatar.
+
+### 5. Let's go! Start the server.
+
+Enjoy skynet, I hope you're happy with yourself.
+
+To get the hubot running, start the server with the `lets-chat` adapter. 
+
 ```
 bin/hubot -a lets-chat
 ```
+
+If everything goes well, your bot will join you in your Let's Chat instance.


### PR DESCRIPTION
- Remove 0.2x install notes
- Link to hubot install docs as suggested by @sibartlett in #7 (and mention the yeoman install process)
- Mention where to find auth tokens to help with confusion like #5
- More detailed configuration notes to help with confusion like #8
- Add the step where you actually create the bot in Let's Chat and name it (to help with confusion on [this thread](https://groups.google.com/forum/#!topic/lets-chat-app/vSKB5Y1n-Ks)
- generally clarify usage scenario and order of installation steps (might help with #18)
